### PR TITLE
Internally public projects support

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -76,6 +76,7 @@ class ApplicationController < ActionController::Base
   end
 
   def project
+    @project ||= Project.find_by_code_and_private_flag(params[:project_id], false)
     @project ||= current_user.projects.find_by_code(params[:project_id])
     @project || render_404
   end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -3,6 +3,7 @@ class DashboardController < ApplicationController
 
   def index
     @projects = current_user.projects_with_events.page(params[:page]).per(40)
+    @public_projects = Project.public_only
     @events = Event.recent_for_user(current_user).limit(20).offset(params[:offset] || 0)
     @last_push = current_user.recent_push
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -13,6 +13,27 @@ class Ability
   def self.project_abilities(user, project)
     rules = []
 
+    if project.public?
+      rules << [
+        #guest
+        :read_project,
+        :read_wiki,
+        :read_issue,
+        :read_milestone,
+        :read_snippet,
+        :read_team_member,
+        :read_merge_request,
+        :read_note,
+        :write_project,
+        :write_issue,
+        :write_note,
+        #reporter
+        :download_code,
+        :write_merge_request,
+        :write_snippet
+      ]
+    end
+
     rules << [
       :read_project,
       :read_wiki,

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -28,7 +28,7 @@ class Project < ActiveRecord::Base
   #
   # Protected attributes
   #
-  attr_protected :private_flag, :owner_id
+  attr_protected :owner_id
 
   #
   # Scopes

--- a/app/roles/authority.rb
+++ b/app/roles/authority.rb
@@ -2,12 +2,12 @@ module Authority
   # Compatible with all access rights
   # Should be rewrited for new access rights
   def add_access(user, *access)
-    access = if access.include?(:admin) 
-               { project_access: UsersProject::MASTER } 
+    access = if access.include?(:admin)
+               { project_access: UsersProject::MASTER }
              elsif access.include?(:write)
-               { project_access: UsersProject::DEVELOPER } 
+               { project_access: UsersProject::DEVELOPER }
              else
-               { project_access: UsersProject::REPORTER } 
+               { project_access: UsersProject::REPORTER }
              end
     opts = { user: user }
     opts.merge!(access)
@@ -19,6 +19,7 @@ module Authority
   end
 
   def repository_readers
+    return ['@all'] if public?
     keys = Key.joins({user: :users_projects}).
       where("users_projects.project_id = ? AND users_projects.project_access = ?", id, UsersProject::REPORTER)
     keys.map(&:identifier) + deploy_keys.map(&:identifier)

--- a/app/views/admin/projects/_form.html.haml
+++ b/app/views/admin/projects/_form.html.haml
@@ -14,6 +14,11 @@
   %hr
   .adv_settings
     %h6 Advanced settings:
+
+    .clearfix
+      = f.label :private_flag, "Private"
+      .input= f.check_box :private_flag
+
     .clearfix
       = f.label :path do
         Path

--- a/app/views/dashboard/index.html.haml
+++ b/app/views/dashboard/index.html.haml
@@ -1,4 +1,4 @@
-- if @projects.any?
+- if @projects.any? || @public_projects.any?
   .projects
     .activities.span8
       = render 'shared/no_ssh'
@@ -30,6 +30,22 @@
                   %strong Last activity:
                   %span= project_last_activity(project)
         .bottom= paginate @projects, theme: "gitlab"
+
+      .projects_box
+        %h5
+          Public Projects
+          %small
+            (#{@public_projects.count})
+        %ul.unstyled
+          - @public_projects.each do |project|
+            %li.wll
+              = link_to project_path(project), class: dom_class(project) do
+                %strong.project_name= truncate(project.name, length: 25)
+                %span.arrow
+                  &rarr;
+                %span.last_activity
+                  %strong Last activity:
+                  %span= project_last_activity(project)
 
       %hr
       %div

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -13,6 +13,11 @@
   %hr
   .adv_settings
     %h6 Advanced settings:
+
+    .clearfix
+      = f.label :private_flag, "Private"
+      .input= f.check_box :private_flag
+
     .clearfix
       = f.label :path do
         Path


### PR DESCRIPTION
Based on #1293 with slight modifications  (see also http://shanetully.com/2012/08/gitlab-internally-public-projects/)
- Abilities for public projects are defined separately in app/models/ability.rb; corresponds to reporter level access
- On dashboard, there's exact same box as "Projects", but with "Public Projects"; the pagination is currently missing and it includes user's public projects
- Events for public projects are not shown on Dashboard; it could be a configuration option but the original implementation is not very performance-wise
